### PR TITLE
feat: 環境変数PATHを表示するように変更

### DIFF
--- a/serverless_inference/src/app.py
+++ b/serverless_inference/src/app.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 import uvicorn
 
 import glob
+import os
 
 app = FastAPI()
 
@@ -12,6 +13,7 @@ def ping():
 
 @app.post("/invocations")
 def transformation():
+    os_env_path = os.environ.get('PATH')
     opt_ml_mode_dir = "/opt/ml/model"
     opt_ml_mode_files = {
         'dir': opt_ml_mode_dir,
@@ -21,7 +23,12 @@ def transformation():
     for file in files:
         opt_ml_mode_files['files'].append(file)
 
-    return {"invocated": opt_ml_mode_files}
+    results = {
+        "opt_ml_mode_files": opt_ml_mode_files,
+        "os_env_path": os_env_path
+    }
+
+    return {"results": results}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 検証内容
### 環境変数PATHの内容について
- ローカル環境での内容
   ```sh
   koba-masa@ZGMF-X42S ~ % curl -X POST http://localhost:8080/invocations
   {"results":{"opt_ml_mode_files":{"dir":"/opt/ml/model","files":[]},"os_env_path":"/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}}
   koba-masa@ZGMF-X42S ~ %
   ```
   ```json
   {
      "results":{
         "opt_ml_mode_files":{
            "dir":"/opt/ml/model",
            "files":[]
         },
         "os_env_path":"/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
      }
   }
   ```
- SageMaker環境での内容
   ```sh
   koba-masa@ZGMF-X42S serverless_inference (feat/verify_path) % sh invoke_serverless_inference.sh 
   --------------------------------------------------
   |                 InvokeEndpoint                 |
   +-------------------+----------------------------+
   |    ContentType    | InvokedProductionVariant   |
   +-------------------+----------------------------+
   |  application/json |  variant-1                 |
   +-------------------+----------------------------+
   {"results":{"opt_ml_mode_files":{"dir":"/opt/ml/model","files":["/opt/ml/model/model.vec"]},"os_env_path":"/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}}%                                                                                                                           
   koba-masa@ZGMF-X42S serverless_inference (feat/verify_path) % 
   ```
   ```json
   {
      "results":{
         "opt_ml_mode_files":{
            "dir":"/opt/ml/model",
            "files":[
               "/opt/ml/model/model.vec"
            ]
         },
         "os_env_path":"/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
      }
   }
   ```