### PR TITLE
feat: pythonコマンドを絶対パスで指定しないように変更

### DIFF
--- a/serverless_inference/Dockerfile
+++ b/serverless_inference/Dockerfile
@@ -15,4 +15,4 @@ WORKDIR ${WORKINGDIR}
 RUN mkdir -p ${WORKINGDIR}
 COPY src/* ${WORKINGDIR}
 
-ENTRYPOINT [ "/usr/local/bin/python", "app.py"]
+ENTRYPOINT [ "python", "app.py"]


### PR DESCRIPTION
## 検証
### pythonコマンドを絶対パスにて指定しない場合にどうなるのか
- 普通に起動してしまった。。。
```
  | 2023-08-08T23:14:49.288+09:00 | INFO: Started server process [16]
  | 2023-08-08T23:14:49.288+09:00 | INFO: Waiting for application startup.
  | 2023-08-08T23:14:49.289+09:00 | INFO: Application startup complete.
  | 2023-08-08T23:14:49.292+09:00 | INFO: Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
  | 2023-08-08T23:14:51.206+09:00 | INFO: 127.0.0.1:59132 - "GET /ping HTTP/1.1" 200 OK
  | 2023-08-08T23:17:44.440+09:00 | INFO: 127.0.0.1:38332 - "POST /invocations HTTP/1.1" 200 OK
```